### PR TITLE
Add config option for clearing gauges

### DIFF
--- a/bufferedstats.go
+++ b/bufferedstats.go
@@ -177,12 +177,11 @@ func (c *BufferedStats) CreateGraphiteMessage(namespace, countGaugeName string,
 
 // clearStats resets the state of all the stat types.
 // - Counters and sets are deleted, but their names are recorded if
-//   persistStats = true.
+//   persistStats is true.
 // - Timers are always cleared because there aren't great semantics for
 //   persisting them.
-// - Gauges are preserved as-is unless persistStats = false so they keep their
-//   current values.
-func (c *BufferedStats) Clear(persistStats bool) {
+// - Gauges are preserved as-is unless persistStats or persistGauges are false.
+func (c *BufferedStats) Clear(persistStats bool, persistGauges bool) {
 	if persistStats {
 		for k := range c.Counts {
 			c.PersistentKeys["count"][k] = struct{}{}
@@ -191,7 +190,8 @@ func (c *BufferedStats) Clear(persistStats bool) {
 		for k := range c.Sets {
 			c.PersistentKeys["set"][k] = struct{}{}
 		}
-	} else {
+	}
+	if !persistStats || !persistGauges {
 		c.Gauges = make(map[string]float64)
 	}
 	c.Timers = make(map[string][]float64)

--- a/bufferedstats_test.go
+++ b/bufferedstats_test.go
@@ -20,6 +20,11 @@ func TestBufferedStatsGauge(t *testing.T) {
 	s.SetGauge("foo", 20)
 	r := s.computeDerived()
 	approx(t, r["gauge"]["foo"], 20.0)
+	s.Clear(true, false)
+	r = s.computeDerived()
+	if _, ok := r["gauge"]["foo"]; ok {
+		t.Fatal("gauges not cleared")
+	}
 }
 
 func TestBufferedStatsSet(t *testing.T) {

--- a/conf.go
+++ b/conf.go
@@ -17,6 +17,7 @@ type Conf struct {
 	Port                     int          `toml:"port"`
 	DebugPort                int          `toml:"debug_port"`
 	ClearStatsBetweenFlushes bool         `toml:"clear_stats_between_flushes"`
+	ClearGauges              bool         `toml:"clear_gauges"`
 	FlushIntervalMS          int          `toml:"flush_interval_ms"`
 	Namespace                string       `toml:"namespace"`
 	OSStats                  *OSStatsConf `toml:"os_stats"`

--- a/conf.toml
+++ b/conf.toml
@@ -26,6 +26,13 @@ debug_port = 8126
 # values.
 clear_stats_between_flushes = false
 
+# By default, gost continuously emits the last value it saw for every gauge.
+# Enabling clear_gauges will cause it to clear all gauges after each flush,
+# meaning clients should emit gauges at least once per flush interval.
+# Gauges are cleared if either clear_stats_between_flushes or clear_gauges
+# are true.
+clear_gauges = false
+
 # Interval to flush to graphite in milliseconds.
 flush_interval_ms = 2000
 

--- a/gost.go
+++ b/gost.go
@@ -260,7 +260,7 @@ func (s *Server) aggregateForwarded() {
 				"distinct_forwarded_metrics_flushed", s.now())
 			log.Printf("Sending %d forwarded stat(s) to graphite.", n)
 			s.outgoing <- msg
-			s.forwardedStats.Clear(!s.conf.ClearStatsBetweenFlushes)
+			s.forwardedStats.Clear(!s.conf.ClearStatsBetweenFlushes, !s.conf.ClearGauges)
 		case <-s.quit:
 			return
 		}
@@ -328,7 +328,7 @@ func (s *Server) aggregateForwarding() {
 			}
 			// Always delete forwarded stats -- they are cleared/preserved
 			// between flushes at the receiving end.
-			s.forwardingStats.Clear(false)
+			s.forwardingStats.Clear(false, false)
 		case <-s.quit:
 			return
 		}
@@ -388,7 +388,7 @@ func (s *Server) aggregate() {
 			n, msg := s.stats.CreateGraphiteMessage(s.conf.Namespace, "distinct_metrics_flushed", s.now())
 			log.Printf("Flushing %d stat(s).", n)
 			s.outgoing <- msg
-			s.stats.Clear(!s.conf.ClearStatsBetweenFlushes)
+			s.stats.Clear(!s.conf.ClearStatsBetweenFlushes, !s.conf.ClearGauges)
 		case <-s.quit:
 			return
 		}

--- a/gost_test.go
+++ b/gost_test.go
@@ -364,6 +364,21 @@ func TestNoForwarding(t *testing.T) {
 	})
 }
 
+func TestClearGauges(t *testing.T) {
+	s := NewTestServer()
+	s.s.conf.ClearStatsBetweenFlushes = false
+	s.s.conf.ClearStatsBetweenFlushes = true
+	s.Start()
+	defer s.Close()
+	s.SendGostMessages(t, "foo:10|g")
+	msg := s.WaitForMessage()
+	approx(t, msg.Parsed["com.example.foo.gauge"].Value, 10.0)
+	msg = s.WaitForMessage()
+	if _, ok := msg.Parsed["com.example.foo.gauge"]; ok {
+		t.Fatal("gauges not cleared")
+	}
+}
+
 func TestSampleRates(t *testing.T) {
 	s := NewStartedTestServer()
 	defer s.Close()


### PR DESCRIPTION
```
# By default, gost continuously emits the last value it saw for every gauge.
# Enabling clear_gauges will cause it to clear all gauges after each flush,
# meaning clients should emit gauges at least once per flush interval.
# Gauges are cleared if either clear_stats_between_flushes or clear_gauges
# are true.
clear_gauges = false
```

A further extension would be to add TTLs so that gauges are cleared after some period instead of after every flush. This would be useful for gauge producers that aren't always running (e.g., a periodic job). Two proposals for this format:
```
foo:10|g|t300 // (milli?)seconds
foo:10|g|t5m  // Go duration format
```