### PR TITLE
Wait one flush interval before clearing gauges

### DIFF
--- a/bufferedstats_test.go
+++ b/bufferedstats_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"math"
 	"testing"
+	"time"
 )
 
 func TestBufferedStatsCounter(t *testing.T) {
@@ -18,9 +19,11 @@ func TestBufferedStatsGauge(t *testing.T) {
 	s := NewBufferedStats(2000)
 	s.SetGauge("foo", 10)
 	s.SetGauge("foo", 20)
+	s.SetGaugeExpiration("foo", 10*time.Millisecond)
 	r := s.computeDerived()
 	approx(t, r["gauge"]["foo"], 20.0)
-	s.Clear(true, false)
+	time.Sleep(20 * time.Millisecond)
+	s.Clear(true)
 	r = s.computeDerived()
 	if _, ok := r["gauge"]["foo"]; ok {
 		t.Fatal("gauges not cleared")


### PR DESCRIPTION
This adds some leeway to clients sending gauges once every flush interval so the gauge will persist even if the client misses one flush deadline.

This code can be reused if we add configurable gauge TTLs (`foo.gauge|g|t300`).