### PR TITLE
Fix dev_id -> (major, minor) conversion

### DIFF
--- a/osstats.go
+++ b/osstats.go
@@ -1,5 +1,25 @@
 package main
 
+const (
+	majorMask uint64 = 0xfff
+	minorMask uint64 = 0xff
+)
+
+// A blockDev is a Linux block device number.
+type blockDev struct {
+	major int
+	minor int
+}
+
+// decomposeDevNumber extracts the major and minor device numbers for a Linux
+// block device. See the major/minor macros in Linux's sysmacros.h.
+func decomposeDevNumber(dev uint64) blockDev {
+	return blockDev{
+		major: int(((dev >> 8) & majorMask) | ((dev >> 32) & ^majorMask)),
+		minor: int((dev & minorMask) | ((dev >> 12) & ^minorMask)),
+	}
+}
+
 func (s *Server) osGauge(name string, value float64) {
 	s.incoming <- &Stat{
 		Type:  StatGauge,

--- a/osstats_linux.go
+++ b/osstats_linux.go
@@ -43,12 +43,6 @@ func (s *Server) InitOSData() {
 // Linux counter stats represented by unsigned ints/longs. These can roll over.
 type counterStats []uint64
 
-// A blockDev is a Linux block device number.
-type blockDev struct {
-	major int
-	minor int
-}
-
 // Sub subtracts two counterStats, assuming they are the same length.
 // TODO(caleb): This should probably handle integer rollover. Different proc
 // counters might have different counter sizes, though.
@@ -283,20 +277,6 @@ func (s *Server) reportDiskStats() error {
 	}
 
 	return nil
-}
-
-const (
-	majorMask uint64 = 0xfff
-	minorMask uint64 = 0xff
-)
-
-// decomposeDevNumber extracts the major and minor device numbers for a Linux
-// block device. See the major/minor macros in Linux's sysmacros.h.
-func decomposeDevNumber(dev uint64) blockDev {
-	return blockDev{
-		major: int(((dev >> 8) & majorMask) | ((dev >> 32) & ^majorMask)),
-		minor: int((dev & minorMask) | ((dev >> 12) & ^minorMask)),
-	}
 }
 
 func (s *Server) checkOSStats() {

--- a/osstats_linux.go
+++ b/osstats_linux.go
@@ -294,7 +294,7 @@ const (
 // block device. See the major/minor macros in Linux's sysmacros.h.
 func decomposeDevNumber(dev uint64) blockDev {
 	return blockDev{
-		major: int(((dev >> 8) & minorMask) | ((dev >> 32) & ^majorMask)),
+		major: int(((dev >> 8) & majorMask) | ((dev >> 32) & ^majorMask)),
 		minor: int((dev & minorMask) | ((dev >> 12) & ^minorMask)),
 	}
 }

--- a/osstats_test.go
+++ b/osstats_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestDecomposeDevNumber(t *testing.T) {
+	for _, tt := range []struct {
+		dev  uint64
+		want blockDev
+	}{
+		{dev: 66305, want: blockDev{259, 1}},
+		{dev: 26266112, want: blockDev{202, 6400}},
+		{dev: 51713, want: blockDev{202, 1}},
+	} {
+		if got := decomposeDevNumber(tt.dev); got != tt.want {
+			t.Fatalf("got: %+v; want: %+v", got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
There's a typo in the conversion func, the original `sysmacros.h` looks like:
```
....
__NTH (gnu_dev_major (unsigned long long int __dev))
{
  return ((__dev >> 8) & 0xfff) | ((unsigned int) (__dev >> 32) & ~0xfff);
}

__extension__ __extern_inline __attribute_const__ unsigned int
__NTH (gnu_dev_minor (unsigned long long int __dev))
{
  return (__dev & 0xff) | ((unsigned int) (__dev >> 12) & ~0xff);
}
.....
```