### PR TITLE
Obtain nCPU via `proc.Stat()`

### DIFF
--- a/osstats_linux.go
+++ b/osstats_linux.go
@@ -13,15 +13,16 @@ import (
 
 var (
 	loadAvgTypes = []int{1, 5, 15}
-	nCPU float64
+	nCPU         float64
 )
 
-// init obtains nCPU using `proc.Stat()`, because `runtime.NumCPU()` doesn't
-// account for isolcpus.
 func init() {
+	// Use proc to determine the number of CPUs.
+	// This may be different from what runtime.NumCPU gives because
+	// the gost process may have a restricted affinity mask.
 	stat, err := proc.Stat()
 	if err != nil {
-		log.Fatal("Cannot obtain CPU stats: ", err)
+		log.Fatalln("Cannot obtain CPU stats:", err)
 	}
 	nCPU = float64(len(stat.Cpus))
 }

--- a/osstats_linux.go
+++ b/osstats_linux.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -14,8 +13,18 @@ import (
 
 var (
 	loadAvgTypes = []int{1, 5, 15}
-	nCPU         = float64(runtime.NumCPU())
+	nCPU float64
 )
+
+// init obtains nCPU using `proc.Stat()`, because `runtime.NumCPU()` doesn't
+// account for isolcpus.
+func init() {
+	stat, err := proc.Stat()
+	if err != nil {
+		log.Fatal("Cannot obtain CPU stats: ", err)
+	}
+	nCPU = float64(len(stat.Cpus))
+}
 
 type OSData struct {
 	netDevices []string // e.g., ["lo", "eth0"]


### PR DESCRIPTION
Obtain nCPU via `proc.Stat()`, because golang `runtime.NumCPU()` doesn't account for isolcpus.